### PR TITLE
use _exit instead of exit

### DIFF
--- a/tsh.c
+++ b/tsh.c
@@ -217,7 +217,7 @@ void eval(char *cmdline)
 	    /* Now load and run the program in the new job */
 	    if (execve(argv[0], argv, environ) < 0) {
 		printf("%s: Command not found\n", argv[0]);
-		exit(0);
+		_exit(0);//Modify: use "exit(0) instead of exit(0)"
 	    }
 	}
 


### PR DESCRIPTION
I think it is better that use use "_exit" instead of "exit" in Line 220 in tsh.c.

This is the reason I saw :
URL: https://stackoverflow.com/questions/5422831/what-is-the-difference-between-using-exit-exit-in-a-conventional-linux-fo

You should use _exit (or its synonym _Exit) to abort the child program when the exec fails, because in this situation, the child process may interfere with the parent process' external data (files) by calling its atexit handlers, calling its signal handlers, and/or flushing buffers.

For the same reason, you should also use _exit in any child process that does not do an exec, but those are rare.

In all other cases, just use exit. As you partially noted yourself, every process in Unix/Linux (except one, init) is the child of another process, so using _exit in every child process would mean that exit is useless outside of init.